### PR TITLE
Modify target in-place unless mutate is set to false

### DIFF
--- a/src/Animation.js
+++ b/src/Animation.js
@@ -14,6 +14,7 @@ export class Animation {
   #timer;
   #startTime = 0;
   #isStarted = false;
+  #mutate = true;
 
   constructor(manager) {
     this.#timer = manager.timer;
@@ -63,6 +64,12 @@ export class Animation {
     return this;
   }
 
+  mutate(flag) {
+    this.#mutate = flag;
+
+    return this;
+  }
+
   start() {
     for (const key of Object.keys(this.#to)) {
       this.#from[key] = this.#target[key];
@@ -91,8 +98,13 @@ export class Animation {
     const result = {};
 
     for (const key of keys) {
-      result[key] =
+      const value =
         this.#from[key] + easingValue * (this.#to[key] - this.#from[key]);
+      result[key] = value;
+
+      if (this.#mutate) {
+        this.#target[key] = value;
+      }
     }
 
     this.#events.dispatch("update", result);


### PR DESCRIPTION
# Changes

Target object will now have it's properties modified in place. This behavior can be disabled using `animation.mutate(false)`.

If mutation is disabled, the tweening properties can be accessed in the `on('update', (values) => ...)` callback.


# Checklist

 - [x] Add one of these labels: `major`, `minor`, `patch` or `skip-release`.
